### PR TITLE
fixes error when creating the image with packer

### DIFF
--- a/ndrsv2_centos-7.7_gen2_ib_nvidia.json
+++ b/ndrsv2_centos-7.7_gen2_ib_nvidia.json
@@ -98,6 +98,9 @@
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E sh '{{ .Path }}'",
             "inline": [
                 "chmod +x /tmp/install.sh",
+                "chmod +x /tmp/install_utils.sh",
+                "chmod +x /tmp/install_mellanoxofed.sh",
+                "chmod +x /tmp/hpc-tuning.sh",
                 "/tmp/install.sh"
             ],
             "inline_shebang": "/bin/bash -e",


### PR DESCRIPTION
This fixed an error (Permission denied), when creating the image with packer.